### PR TITLE
Modify cluster names to source,target

### DIFF
--- a/create.sh
+++ b/create.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Creates two k3d clusters: east, & west.
+# Creates two k3d clusters: source (east), & west (target).
 #
 
 set -eu
@@ -9,7 +9,7 @@ set -x
 export ORG_DOMAIN="${ORG_DOMAIN:-cluster.local}"
 
 port=6440
-for cluster in east west ; do
+for cluster in source target ; do
     if k3d cluster get "$cluster" >/dev/null 2>&1 ; then
         echo "Already exists: $cluster" >&2
     else

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Creates two k3d clusters: east, & west.
+# Creates two k3d clusters: (source) east, & (target) west.
 #
 
 set -eu
@@ -32,7 +32,7 @@ step certificate create \
     --profile root-ca \
     --no-password  --insecure --force
 
-for cluster in east west ; do
+for cluster in source target ; do
     # Check that the cluster is up and running.
     while ! $LINKERD --context="k3d-$cluster" check --pre ; do :; done
 

--- a/link.sh
+++ b/link.sh
@@ -24,12 +24,12 @@ fetch_credentials() {
             --api-server-address="https://${lb_ip}:6443")" 
 }
 
-# East & West get access to each other.
-fetch_credentials east | kubectl --context=k3d-west apply -n linkerd-multicluster -f -
+# East (source) & West (target) get access to each other.
+fetch_credentials source | kubectl --context=k3d-target apply -n linkerd-multicluster -f -
 
-fetch_credentials west | kubectl --context=k3d-east apply -n linkerd-multicluster -f -
+fetch_credentials target | kubectl --context=k3d-source apply -n linkerd-multicluster -f -
 
 sleep 10
-for c in east west ; do
+for c in source target ; do
     $LINKERD --context="k3d-$c" mc check
 done


### PR DESCRIPTION
Steps I follow for running the linkerd multicluster integration test:
- Run `./create.sh` and `./install.sh`
- Install linkerd-viz in both clusters via `linkerd viz install | kubectl apply -f -`
- Run `./link.sh`
- Change directory to `linkerd2` (my branch), and run `go test test/integration/multicluster/target3/target_test.go -v -integration-tests -linkerd ~/.linkerd2/bin/linkerd --multicluster`