### PR TITLE
Updates to `deploy.sh` and the `k3d cluster create` command

### DIFF
--- a/create.sh
+++ b/create.sh
@@ -16,7 +16,7 @@ for cluster in east west ; do
         k3d cluster create "$cluster" \
             --api-port="$((port++))" \
             --network=multicluster-example \
-            --k3s-server-arg="--cluster-domain=$cluster.${ORG_DOMAIN}" \
+            --k3s-arg="--cluster-domain=$cluster.${ORG_DOMAIN}@server:0" \
             --wait
     fi
 done

--- a/deploy.sh
+++ b/deploy.sh
@@ -22,22 +22,11 @@ kubectl --context=k3d-east apply -f "./east/curl.yml"
 
 # Deploy an 'nginx-set' statefulset, along with a headless 'nginx-svc' to 
 # cluster west;  used as poc app to mirror a headless service from target to 
-# source. The service is already exported.
-# curling this from source cluster should work.
+# source.
 # 
 echo "Applying statefulset to west"
 kubectl --context=k3d-west apply -f "./west/nginx-statefulset.yml"
 sleep 2
-
-# Deploy two invalid headless services: 'nginx-no-ports' & 'nginx-invalid-deploy-svc'
-# nginx-no-ports: should not be exported in east and have an event associated in west
-# nginx-invalid-deploy-svc: should not be exported in east as headless but as clusterIP
-#
-echo "Applying invalid exported headless service manifests"
-kubectl --context=k3d-west apply -f "./west/nginx-statefulset-no-ports.yml"
-kubectl --context=k3d-west annotate svc nginx-no-ports "mirror.linkerd.io/exported=\"true\""
-sleep 2
-kubectl --context=k3d-west apply -f "./west/nginx-deployment.yml"
 
 echo "Done!"
 


### PR DESCRIPTION
- In `deploy.sh`: Removed "This service is already exported" because we
  actually need to do that manually, and the tests at the end whose
  manifests are not in the repo.
- Updated the `k3d cluster create` command in `create.sh` to work in
  more recent k3d versions